### PR TITLE
log the base directory when searching all sub-paths for wc3 exe

### DIFF
--- a/src/main/java/net/moonlightflower/wc3libs/port/NotFoundException.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/NotFoundException.java
@@ -10,4 +10,8 @@ public class NotFoundException extends Exception {
     public NotFoundException(@Nonnull Exception enclosedException) {
         super(enclosedException);
     }
+
+    public NotFoundException(@Nonnull String message) {
+        super(message);
+    }
 }

--- a/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
@@ -5,28 +5,28 @@ import net.moonlightflower.wc3libs.port.win.registry.WinRegistryGameExeFinder;
 
 import javax.annotation.Nonnull;
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 
 public class WinGameExeFinder extends GameExeFinder {
-    public final static File WAR3_EXE_PATH = new File("war3.exe");
-    public final static File WARCRAFT_III_EXE_PATH = new File("Warcraft III.exe");
-    public final static File FROZEN_THRONE_EXE_PATH = new File("Frozen Throne.exe");
+    public final static Path WAR3_EXE_PATH = new File("war3.exe").toPath();
+    public final static Path WARCRAFT_III_EXE_PATH = new File("Warcraft III.exe").toPath();
+    public final static Path FROZEN_THRONE_EXE_PATH = new File("Frozen Throne.exe").toPath();
 
-    public final static File X86_DIR = new File("x86");
-    public final static File X64_DIR = new File("x86_64");
+    public final static Path X86_DIR = new File("x86").toPath();
+    public final static Path X64_DIR = new File("x86_64").toPath();
 
-    public final static File RETAIL_DIR = new File("_retail_");
+    public final static Path RETAIL_DIR = new File("_retail_").toPath();
 
-    public final static File RETAIL_X86_DIR = new File(RETAIL_DIR, "x86");
-    public final static File RETAIL_X64_DIR = new File(RETAIL_DIR, "x86_64");
+    public final static Path RETAIL_X86_DIR = RETAIL_DIR.resolve("x86");
+    public final static Path RETAIL_X64_DIR = RETAIL_DIR.resolve("x86_64");
 
-    public final static File X86_EXE_PATH_131 = new File(X86_DIR, WARCRAFT_III_EXE_PATH.toString());
-    public final static File X64_EXE_PATH_131 = new File(X64_DIR, WARCRAFT_III_EXE_PATH.toString());
+    public final static Path X86_EXE_PATH_131 = X86_DIR.resolve(WARCRAFT_III_EXE_PATH);
+    public final static Path X64_EXE_PATH_131 = X64_DIR.resolve(WARCRAFT_III_EXE_PATH);
 
-    public final static File X86_EXE_PATH_132 = new File(RETAIL_X86_DIR, WARCRAFT_III_EXE_PATH.toString());
-    public final static File X64_EXE_PATH_132 = new File(RETAIL_X64_DIR, WARCRAFT_III_EXE_PATH.toString());
+    public final static Path X86_EXE_PATH_132 = RETAIL_X86_DIR.resolve(WARCRAFT_III_EXE_PATH);
+    public final static Path X64_EXE_PATH_132 = RETAIL_X64_DIR.resolve(WARCRAFT_III_EXE_PATH);
 
     protected GameExeFinder getRegistryGameExeFinder() {
         return new WinRegistryGameExeFinder();
@@ -101,10 +101,11 @@ public class WinGameExeFinder extends GameExeFinder {
                 X64_EXE_PATH_131,
                 X86_EXE_PATH_132,
                 X64_EXE_PATH_132)
-            .map(relativePath -> new File(dir, relativePath.toString()))
-            .filter(File::exists)
+            .map(relativePath -> dir.toPath().resolve(relativePath))
+            .filter(Files::exists)
             .findFirst()
-            .orElseThrow(() -> new NotFoundException("tried all known wc3 sub-paths in " + dir));
+            .orElseThrow(() -> new NotFoundException("tried all known wc3 sub-paths in " + dir.getAbsolutePath()))
+            .toFile();
     }
 
     @Nonnull

--- a/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class WinGameExeFinder extends GameExeFinder {
     public final static File WAR3_EXE_PATH = new File("war3.exe");
@@ -93,22 +94,17 @@ public class WinGameExeFinder extends GameExeFinder {
                 break;
         }
 
-        List<File> relativeSearchPaths = Arrays.asList(WARCRAFT_III_EXE_PATH,
+        return Stream.of(WARCRAFT_III_EXE_PATH,
                 FROZEN_THRONE_EXE_PATH,
                 WAR3_EXE_PATH,
                 X86_EXE_PATH_131,
                 X64_EXE_PATH_131,
                 X86_EXE_PATH_132,
-                X64_EXE_PATH_132
-        );
-
-        for (File relativeSearchPath : relativeSearchPaths) {
-            File inDirPath = new File(dir, relativeSearchPath.toString());
-
-            if (inDirPath.exists()) return inDirPath;
-        }
-
-        throw new NotFoundException(new Exception("tried: " + relativeSearchPaths.toString()));
+                X64_EXE_PATH_132)
+            .map(relativePath -> new File(dir, relativePath.toString()))
+            .filter(File::exists)
+            .findFirst()
+            .orElseThrow(() -> new NotFoundException("tried all known wc3 sub-paths in " + dir));
     }
 
     @Nonnull

--- a/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/win/WinGameExeFinder.java
@@ -7,17 +7,18 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 public class WinGameExeFinder extends GameExeFinder {
-    public final static Path WAR3_EXE_PATH = new File("war3.exe").toPath();
-    public final static Path WARCRAFT_III_EXE_PATH = new File("Warcraft III.exe").toPath();
-    public final static Path FROZEN_THRONE_EXE_PATH = new File("Frozen Throne.exe").toPath();
+    public final static Path WAR3_EXE_PATH = Paths.get("war3.exe");
+    public final static Path WARCRAFT_III_EXE_PATH = Paths.get("Warcraft III.exe");
+    public final static Path FROZEN_THRONE_EXE_PATH = Paths.get("Frozen Throne.exe");
 
-    public final static Path X86_DIR = new File("x86").toPath();
-    public final static Path X64_DIR = new File("x86_64").toPath();
+    public final static Path X86_DIR = Paths.get("x86");
+    public final static Path X64_DIR = Paths.get("x86_64");
 
-    public final static Path RETAIL_DIR = new File("_retail_").toPath();
+    public final static Path RETAIL_DIR = Paths.get("_retail_");
 
     public final static Path RETAIL_X86_DIR = RETAIL_DIR.resolve("x86");
     public final static Path RETAIL_X64_DIR = RETAIL_DIR.resolve("x86_64");


### PR DESCRIPTION
In the current version of code, the exception here logs all the paths that wc3libs tries, but it doesn't mention the base path that was requested.

For debugging https://github.com/wurstscript/WurstScript/issues/1034, it seems more valuable to see what base path was provided by consumer. It is no longer useful to log the "paths tested" since we know that part to be working.