### PR TITLE
introduce UnsupportedPlatformException to find interface

### DIFF
--- a/src/main/java/net/moonlightflower/wc3libs/port/StdGameExeFinder.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/StdGameExeFinder.java
@@ -24,21 +24,13 @@ public class StdGameExeFinder extends GameExeFinder {
         if (Orient.isMacSystem()) {
             GameExeFinder macGameExeFinder = getMacGameExeFinder();
 
-            try {
-                return macGameExeFinder.get();
-            } catch (NotFoundException e) {
-                throw e;
-            }
+            return macGameExeFinder.get();
         } else if (Orient.isWindowsSystem()) {
             GameExeFinder winGameExeFinder = getWinGameExeFinder();
 
-            try {
-                return winGameExeFinder.get();
-            } catch (NotFoundException e) {
-                throw e;
-            }
+            return winGameExeFinder.get();
         } else {
-            throw new NotFoundException(new Exception("system not supported: " + Orient.getSystem()));
+            throw new UnsupportedPlatformException("system not supported: " + Orient.getSystem());
         }
     }
 }

--- a/src/main/java/net/moonlightflower/wc3libs/port/UnsupportedPlatformException.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/UnsupportedPlatformException.java
@@ -1,0 +1,7 @@
+package net.moonlightflower.wc3libs.port;
+
+public class UnsupportedPlatformException extends RuntimeException {
+    public UnsupportedPlatformException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/wc3libs/misc/StateTest.java
+++ b/src/test/java/wc3libs/misc/StateTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 import java.util.Collection;
 
 public class StateTest {
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test()
     public void test() {
         Class c = AbilityMetaSLK.State.class;


### PR DESCRIPTION
This allows a consuming library to distinguish a NotFound from an UnsupportedPlatform error

In particular I'll use this as a follow-up for https://github.com/wurstscript/WurstScript/pull/1075