### PR TITLE
State why the baseline is Java 25, and drop an unnecessary JVM flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ With Wc3libs we aim to offer a feature-complete, easy, plug & play solution for 
 | 1.2.x | 17 |
 
 The Java 25 baseline comes from [JMPQ3](https://github.com/inwc3/JMPQ3) 2.0,
-which wc3libs uses to read and write MPQ archives.
+which wc3libs uses to read and write MPQ archives. What took JMPQ3 past Java 21
+was adopting the foreign function and memory API in its read layer: an archive
+is mapped into an `Arena`-scoped `MemorySegment` rather than a
+`MappedByteBuffer`, so the mapping is released the moment the archive is closed
+instead of whenever the garbage collector gets round to it. That is what makes
+rebuilding a map in place work on Windows, where the old mapping kept the file
+locked long after `close()` had returned.
+
+Nothing here calls a restricted method, so no `--enable-native-access` flag is
+needed to read archives.
 
 # Usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,6 @@ dependencies {
 
 test {
     useTestNG()
-    // JMPQ3 reads archives through memory-mapped segments (FFM), which is a
-    // restricted operation; without this every archive the tests open logs a
-    // warning.
-    jvmArgs '--enable-native-access=ALL-UNNAMED'
     testLogging {
         events 'failed'
         exceptionFormat 'full'


### PR DESCRIPTION
The requirements table said which Java version without saying why.

The reason is JMPQ3 2.0's read layer: it maps an archive into an `Arena`-scoped `MemorySegment` instead of a `MappedByteBuffer`, so the mapping is released when the archive is closed rather than whenever the collector gets round to it — which is what makes rebuilding a map in place work on Windows, where the old mapping kept the file locked long after `close()` returned. Adopting that API is what took JMPQ3 past Java 21; 25 is the version its consumers already run. [JMPQ3's `AUDIT.md`](https://github.com/inwc3/JMPQ3/blob/master/AUDIT.md) records the same reasoning.

## A correction that came out of checking it

The `--enable-native-access=ALL-UNNAMED` I added to the test JVM in #96 was cargo cult, and the comment on it — that every archive opened without it logs a warning — was simply wrong. Mapping a file into a segment is not a restricted operation: it is bounds-checked and arena-scoped, so there is nothing to permit.

Verified rather than assumed:

- The suite passes under `--illegal-native-access=deny` with no enable flag at all.
- Removing the flag produces no warning on any of the archive-reading tests.
- JMPQ3 calls no restricted method anywhere — no `Linker`, `reinterpret`, `libraryLookup` or `withTargetLayout`.

So the flag and its comment are gone, and the README states that none is needed rather than leaving the next person to wonder why one was there.

`./gradlew clean check jar`: 184 tests, 0 failures.