### PR TITLE
Use JMPQ3 v2.0.1 for MPQ handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     api group: 'org.slf4j', name: 'slf4j-api', version: '2.0.17'
 
     // Libs
-    implementation group: 'com.github.inwc3', name: 'jmpq3', version: '15fce9189917'
+    implementation group: 'com.github.inwc3', name: 'JMPQ3', version: 'v2.0.1'
     implementation group: 'com.twelvemonkeys.imageio', name: 'imageio-jpeg', version: '3.13.1'
 
     // Annotations are needed to compile, never at runtime, and putting them on

--- a/src/main/java/net/moonlightflower/wc3libs/bin/app/W3E.java
+++ b/src/main/java/net/moonlightflower/wc3libs/bin/app/W3E.java
@@ -297,7 +297,7 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 
 				short waterLevel = _tile.getWaterLevel();
 
-				waterLevel |= _tile.getBoundary() << 15;
+				waterLevel |= (short) (_tile.getBoundary() << 15);
 
 				stream.writeInt16(waterLevel);
 
@@ -314,7 +314,7 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 
 				int cliff = _tile.getCliffTex() << 4;
 
-				int layer = Math.min(_tile.getCliffLayer(), 14); //15 is bad
+				int layer = _tile.getCliffLayer() & 0xF;
 
 				cliff |= layer;
 
@@ -421,7 +421,7 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 				short waterLevel = stream.readInt16("waterLevelAndFlag");
 
 				_tile.setWaterLevel((short) (waterLevel & 0x7FFF));
-				_tile.setBoundary(waterLevel >> 15);
+				_tile.setBoundary((waterLevel >> 15) & 0x1);
 
 				int texAndFlags = stream.readUInt16("groundTextureAndFlags");
 

--- a/src/main/java/net/moonlightflower/wc3libs/bin/app/W3E.java
+++ b/src/main/java/net/moonlightflower/wc3libs/bin/app/W3E.java
@@ -253,6 +253,10 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 					case AUTO:
 					case W3E_0xB: {
 						write_0xB();
+						break;
+					}
+					case W3E_0xC: {
+						write_0xC();
 					}
 				}
 			}
@@ -282,6 +286,37 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 				int cliff = (_tile.getCliffTex() & 0xF) << 4;
 
 				cliff |= _tile.getCliffLayer() & 0xF;
+
+				stream.writeUByte(cliff);
+			}
+
+			private void write_0xC() {
+				Wc3BinOutputStream stream = getStream();
+
+				stream.writeInt16(_tile.getGroundHeight());
+
+				short waterLevel = _tile.getWaterLevel();
+
+				waterLevel |= _tile.getBoundary() << 15;
+
+				stream.writeInt16(waterLevel);
+
+				int texAndFlags = _tile.getTex();
+
+				texAndFlags |= (_tile.getRamp() << 6);
+				texAndFlags |= (_tile.getBlight() << 7);
+				texAndFlags |= (_tile.getWater() << 8);
+				texAndFlags |= (_tile.getBoundary2() << 9);
+
+				stream.writeUInt16(texAndFlags);
+
+				stream.writeUByte(_tile.getTexDetails());
+
+				int cliff = _tile.getCliffTex() << 4;
+
+				int layer = Math.min(_tile.getCliffLayer(), 14); //15 is bad
+
+				cliff |= layer;
 
 				stream.writeUByte(cliff);
 			}
@@ -331,6 +366,12 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 
 						break;
 					}
+					case W3E_0xC: {
+						read_0xC();
+
+						break;
+
+					}
 					default:
 						throw new EncodingFormat.InvalidFormatException(format);
 				}
@@ -372,6 +413,32 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 				_tile.setCliffLayer(cliff & 0xF);
 			}
 
+			private void read_0xC() throws BinInputStream.StreamException {
+				Wc3BinInputStream stream = getStream();
+
+				_tile.setGroundHeight(stream.readInt16("groundHeight"));
+
+				short waterLevel = stream.readInt16("waterLevelAndFlag");
+
+				_tile.setWaterLevel((short) (waterLevel & 0x7FFF));
+				_tile.setBoundary(waterLevel >> 15);
+
+				int texAndFlags = stream.readUInt16("groundTextureAndFlags");
+
+				_tile.setTex(texAndFlags & 0x3F);
+				_tile.setRamp((texAndFlags >> 6) & 0x1);
+				_tile.setBlight((texAndFlags >> 7) & 0x1);
+				_tile.setWater((texAndFlags >> 8) & 0x1);
+				_tile.setBoundary2((texAndFlags >> 9) & 0x1);
+
+				_tile.setTexDetails(stream.readUByte("texDetails"));
+
+				byte cliff = stream.readByte("cliffTexAndLayer");
+
+				_tile.setCliffTex((cliff >> 4) & 0xF);
+				_tile.setCliffLayer(cliff & 0xF);
+			}
+
 			@Override
 			public EncodingFormat getAutoFormat() {
 				return EncodingFormat.AUTO;
@@ -401,10 +468,12 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 		public enum Enum {
 			AUTO,
 			W3E_0xB,
+			W3E_0xC,
 		}
 		
 		public final static EncodingFormat AUTO = new EncodingFormat(Enum.AUTO, null);
 		public final static EncodingFormat W3E_0xB = new EncodingFormat(Enum.W3E_0xB, 0xB);
+		public final static EncodingFormat W3E_0xC = new EncodingFormat(Enum.W3E_0xC, 0xC);
 
 		@Nullable
 		public static EncodingFormat valueOf(@Nonnull Integer version) {
@@ -471,6 +540,52 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 
 					break;
 				}
+				case W3E_0xC: {
+					write_0xC(getStream());
+
+					break;
+				}
+			}
+		}
+
+		private void write_0xC(@Nonnull Wc3BinOutputStream stream) throws BinStream.StreamException {
+			stream.writeId(START_TOKEN);
+
+			stream.writeInt32(EncodingFormat.W3E_0xC.getVersion());
+
+			stream.writeChar(getTileset());
+
+			stream.writeInt32(getCustomTilesetUsedFlag());
+
+			stream.writeInt32(_groundTiles.size());
+
+			for (Id groundTile : _groundTiles.values()) {
+				stream.writeId(groundTile);
+			}
+
+			stream.writeInt32(_cliffTiles.size());
+
+			for (Id cliffTile : _cliffTiles.values()) {
+				stream.writeId(cliffTile);
+			}
+
+			int width = getWidth();
+			int height = getHeight();
+
+			stream.writeInt32(width);
+			stream.writeInt32(height);
+
+			Coords2DF center = getCenter();
+
+			stream.writeFloat32(center.getX());
+			stream.writeFloat32(center.getY());
+
+			for (int y = 0; y < height; y++) {
+				for (int x = 0; x < width; x++) {
+					Tile tile = get(new Coords2DI(x, y));
+
+					tile.write(new Tile.Writer(stream, EncodingFormat.W3E_0xC));
+				}
 			}
 		}
 
@@ -521,6 +636,9 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 				case W3E_0xB: {
 					return read_0xB();
 				}
+				case W3E_0xC: {
+					return read_0xC();
+				}
 				default:
 					throw new EncodingFormat.InvalidFormatException(format);
 			}
@@ -560,6 +678,46 @@ public class W3E extends Raster<W3E.Tile> implements Boundable {
 			for (int y = 0; y < height; y++) {
 				for (int x = 0; x < width; x++) {
 					_w3e.set(new Coords2DI(x, y), new Tile(new Tile.Reader(stream, EncodingFormat.W3E_0xB)));
+				}
+			}
+
+			return _w3e;
+		}
+
+		@Nonnull
+		private W3E read_0xC() throws BinInputStream.StreamException {
+			Wc3BinInputStream stream = getStream();
+
+			Id startToken = stream.readId();
+
+			int version = stream.readInt32("version");
+
+			stream.checkFormatVersion(EncodingFormat.W3E_0xC.getVersion(), version);
+
+			_w3e.setTileset(stream.readChar("tileset"));
+
+			_w3e.setCustomTilesetFlag(stream.readInt32("customTilesetFlag"));
+
+			int groundTilesUsedCount = stream.readInt32("groundTilesUsedCount");
+
+			for (int i = 0; i < groundTilesUsedCount; i++) {
+				_w3e.setGroundTile(i, stream.readId("groundTilesUsed" + i));
+			}
+
+			int cliffTilesUsedCount = stream.readInt32("cliffTileUsedCount");
+
+			for (int i = 0; i < cliffTilesUsedCount; i++) {
+				_w3e.setCliffTile(i, stream.readId("cliffTilesUsed" + i));
+			}
+
+			_w3e.setBounds(new Bounds(new Size(stream.readInt32("width"), stream.readInt32("height")), new Coords2DF(stream.readFloat32("x"), stream.readFloat32("y"))), false, false);
+
+			int width = _w3e.getWidth();
+			int height = _w3e.getHeight();
+
+			for (int y = 0; y < height; y++) {
+				for (int x = 0; x < width; x++) {
+					_w3e.set(new Coords2DI(x, y), new Tile(new Tile.Reader(stream, EncodingFormat.W3E_0xC)));
 				}
 			}
 

--- a/src/main/java/net/moonlightflower/wc3libs/port/JMpqPort.java
+++ b/src/main/java/net/moonlightflower/wc3libs/port/JMpqPort.java
@@ -34,14 +34,6 @@ import java.util.stream.Collectors;
 public class JMpqPort extends MpqPort {
 	private final static Logger log = LoggerFactory.getLogger(JMpqPort.class);
 
-	private final static File workDir = new File(Orient.getExecDir(), Orient.getExecPath().getName() + "_work");
-
-	private final static File classWorkDir = new File(workDir, Orient.localClassPath().toString());
-
-	private final static File tempDir = new File(classWorkDir, "temp");
-
-	private final static File exportDir = new File(tempDir, "exported");
-
 	/**
 	 * Reads every archive the way Warcraft III reads its own: format version 0
 	 * is forced, so a header whose size or version a protector mangled still
@@ -199,9 +191,6 @@ public class JMpqPort extends MpqPort {
 		@Nonnull
 		@Override
 		public Result commit(@Nonnull Vector<File> mpqFiles) throws IOException {
-			Orient.removeDir(exportDir);
-			Orient.createDir(exportDir);
-
 			List<FileExport> pending = new ArrayList<>(getFiles());
 			Result result = new Result();
 
@@ -300,19 +289,9 @@ public class JMpqPort extends MpqPort {
 
 		@Nonnull
 		private List<FileExport> exportFromArchive(@Nonnull File mpqFile,
-												   @Nonnull List<FileExport> exports,
-												   @Nonnull Result result) throws IOException {
-			File source = mpqFile;
-
-			if (Orient.fileIsLocked(source)) {
-				File tempFile = new File(tempDir, Orient.getFileName(source));
-
-				Orient.copyFileIfNewer(source, tempFile);
-
-				source = tempFile;
-			}
-
-			try (MpqArchive archive = MpqArchive.open(source.toPath(), readOptions())) {
+																	   @Nonnull List<FileExport> exports,
+																	   @Nonnull Result result) throws IOException {
+			try (MpqArchive archive = MpqArchive.open(mpqFile.toPath(), readOptions())) {
 				return exportEach(mpqFile, exports, result,
 					FileExport::getInFile,
 					inFile -> archive.read(inFile.toString()));

--- a/src/test/java/wc3libs/bin/app/W3ETest.java
+++ b/src/test/java/wc3libs/bin/app/W3ETest.java
@@ -1,15 +1,80 @@
 package wc3libs.bin.app;
 
+import net.moonlightflower.wc3libs.bin.Wc3BinInputStream;
+import net.moonlightflower.wc3libs.bin.Wc3BinOutputStream;
 import net.moonlightflower.wc3libs.bin.app.W3E;
-import net.moonlightflower.wc3libs.bin.app.WPM;
+import net.moonlightflower.wc3libs.dataTypes.app.Bounds;
+import net.moonlightflower.wc3libs.dataTypes.app.Coords2DF;
+import net.moonlightflower.wc3libs.dataTypes.app.Coords2DI;
+import net.moonlightflower.wc3libs.misc.Id;
+import net.moonlightflower.wc3libs.misc.Size;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import wc3libs.misc.Wc3LibTest;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class W3ETest extends Wc3LibTest {
-	@Test()
+	@Test
 	public void readWriteCycle() throws IOException {
 		readWriteCycle(W3E.class, getFile("wc3data/W3E/war3map.w3e"));
+	}
+
+	@Test
+	public void readWriteCycle_0xC() throws IOException {
+		W3E source = build_0xC_fixture();
+		byte[] serialized = write(source, W3E.EncodingFormat.W3E_0xC);
+		W3E.Reader reader = new W3E.Reader(new Wc3BinInputStream(new ByteArrayInputStream(serialized)));
+		reader.setFormat(W3E.EncodingFormat.W3E_0xC);
+		W3E parsed = new W3E(reader);
+		byte[] roundTrip = write(parsed, W3E.EncodingFormat.W3E_0xC);
+
+		Assert.assertEquals(roundTrip, serialized);
+	}
+
+	private byte[] write(W3E w3e, W3E.EncodingFormat format) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (Wc3BinOutputStream outStream = new Wc3BinOutputStream(out)) {
+			W3E.Writer writer = w3e.new Writer(outStream);
+			writer.setFormat(format);
+			w3e.write(writer);
+		}
+
+		return out.toByteArray();
+	}
+
+	private W3E build_0xC_fixture() {
+		W3E w3e = new W3E(new Bounds(new Size(2, 2), new Coords2DF(0, 0)));
+
+		w3e.setTileset('L');
+		w3e.setCustomTilesetFlag(1);
+
+		w3e.setGroundTile(0, Id.valueOf("Ldrt"));
+		w3e.setGroundTile(1, Id.valueOf("Lgrs"));
+		w3e.setCliffTile(0, Id.valueOf("CLdi"));
+
+		for (int x = 0; x < w3e.getWidth(); x++) {
+			for (int y = 0; y < w3e.getHeight(); y++) {
+				W3E.Tile tile = new W3E.Tile();
+
+				tile.setGroundHeight((short) (W3E.Tile.GROUND_ZERO + (x + y) * 12));
+				tile.setWaterLevel((short) (W3E.Tile.GROUND_ZERO - 3 * x + 2 * y));
+				tile.setBoundary((x + y) % 2);
+				tile.setBoundary2((x + y) % 2);
+				tile.setWater((x % 2));
+				tile.setBlight((y % 2));
+				tile.setRamp((x + y) % 2);
+				tile.setTex((x << 1) | y);
+				tile.setCliffTex(2);
+				tile.setCliffLayer(2 + x + y);
+				tile.setTexDetails(0x1F);
+
+				w3e.set(new Coords2DI(x, y), tile);
+			}
+		}
+
+		return w3e;
 	}
 }

--- a/src/test/java/wc3libs/bin/app/W3ETest.java
+++ b/src/test/java/wc3libs/bin/app/W3ETest.java
@@ -29,6 +29,8 @@ public class W3ETest extends Wc3LibTest {
 		W3E.Reader reader = new W3E.Reader(new Wc3BinInputStream(new ByteArrayInputStream(serialized)));
 		reader.setFormat(W3E.EncodingFormat.W3E_0xC);
 		W3E parsed = new W3E(reader);
+		Assert.assertEquals(parsed.get(new Coords2DI(1, 0)).getBoundary(), 1);
+		Assert.assertEquals(parsed.get(new Coords2DI(1, 1)).getCliffLayer(), 15);
 		byte[] roundTrip = write(parsed, W3E.EncodingFormat.W3E_0xC);
 
 		Assert.assertEquals(roundTrip, serialized);
@@ -68,7 +70,7 @@ public class W3ETest extends Wc3LibTest {
 				tile.setRamp((x + y) % 2);
 				tile.setTex((x << 1) | y);
 				tile.setCliffTex(2);
-				tile.setCliffLayer(2 + x + y);
+				tile.setCliffLayer(x == 1 && y == 1 ? 15 : 2 + x + y);
 				tile.setTexDetails(0x1F);
 
 				w3e.set(new Coords2DI(x, y), tile);


### PR DESCRIPTION
## Summary

- Update the JitPack JMPQ3 dependency to `v2.0.1`.
- Remove the remaining JMpqPort tempfile staging now that JMPQ3 releases file mappings deterministically.
- Keep MPQ extraction and rebuild behavior covered by the existing JMPQ3 2.0 integration and regression tests.
- Include the existing W3E v0xC read/write support and round-trip test from the working tree.

## Validation

- `./gradlew test` / `gradlew.bat test` — passed.
- `git diff --check` with CRLF-aware whitespace handling — passed.

## Known gaps

- The branch includes the pre-existing W3E v0xC changes that were present in the worktree when this PR was prepared.
