### PR TITLE
Preserve MDX extensions during parsing and squishing

### DIFF
--- a/src/main/java/net/moonlightflower/wc3libs/misc/model/MDX.java
+++ b/src/main/java/net/moonlightflower/wc3libs/misc/model/MDX.java
@@ -234,11 +234,7 @@ public class MDX {
 
                 handler.run();
             } else {
-                System.err.println("unknown chunk " + chunkToken + ";" + Arrays.toString(chunkToken.toString().getBytes()));
-
-                long size = stream.readUInt32("header_size");
-
-                stream.skip(size);
+                _chunks.add(new RawChunk(chunkToken, stream));
             }
         }
     }
@@ -290,15 +286,15 @@ public class MDX {
     }
 
     private void read(@Nonnull File file, @Nonnull MDX.EncodingFormat format) throws IOException {
-        read(new Wc3BinInputStream(file), format);
+        try (Wc3BinInputStream stream = new Wc3BinInputStream(file)) {
+            read(stream, format);
+        }
     }
 
     public void write(@Nonnull File file, @Nonnull MDX.EncodingFormat format) throws IOException {
-        Wc3BinOutputStream outStream = new Wc3BinOutputStream(file);
-
-        write(outStream, format);
-
-        outStream.close();
+        try (Wc3BinOutputStream stream = new Wc3BinOutputStream(file)) {
+            write(stream, format);
+        }
     }
 
     private void read(@Nonnull File file) throws IOException {
@@ -306,7 +302,9 @@ public class MDX {
     }
 
     public void write(@Nonnull File file) throws IOException {
-        write(new Wc3BinOutputStream(file));
+        try (Wc3BinOutputStream stream = new Wc3BinOutputStream(file)) {
+            write(stream);
+        }
     }
 
     public MDX() {
@@ -322,7 +320,9 @@ public class MDX {
 
     public void squish() {
         for (Chunk chunk : getChunks()) {
-            if (chunk instanceof GeosetChunk) {
+            if (chunk instanceof SequenceChunk) {
+                squishSequences((SequenceChunk) chunk);
+            } else if (chunk instanceof GeosetChunk) {
                 squishGeoset((GeosetChunk) chunk);
             } else if (chunk instanceof PivotPointChunk) {
                 squishPivot((PivotPointChunk) chunk);
@@ -348,6 +348,10 @@ public class MDX {
                 squishCollisionShape((CollisionShapeChunk) chunk);
             }
         }
+    }
+
+    private void squishSequences(SequenceChunk chunk) {
+        chunk.getSequences().forEach(sequence -> sequence.getExtent().squish());
     }
 
     private void squishCollisionShape(CollisionShapeChunk chunk) {
@@ -464,6 +468,9 @@ public class MDX {
 
     private void squishGeoset(GeosetChunk chunk) {
         chunk.getGeosets().forEach(geoset -> {
+            geoset.getExtent().squish();
+            geoset.getExtents().forEach(Extent::squish);
+
             geoset.getVertexChunk().getVertices().forEach(vertex -> {
                 vertex.setPos(vertex.getPos().squish());
             });

--- a/src/main/java/net/moonlightflower/wc3libs/misc/model/mdx/RawChunk.java
+++ b/src/main/java/net/moonlightflower/wc3libs/misc/model/mdx/RawChunk.java
@@ -1,0 +1,63 @@
+package net.moonlightflower.wc3libs.misc.model.mdx;
+
+import net.moonlightflower.wc3libs.bin.BinInputStream;
+import net.moonlightflower.wc3libs.bin.BinStream;
+import net.moonlightflower.wc3libs.bin.Wc3BinInputStream;
+import net.moonlightflower.wc3libs.bin.Wc3BinOutputStream;
+import net.moonlightflower.wc3libs.misc.Id;
+import net.moonlightflower.wc3libs.misc.model.MDX;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+
+/**
+ * An MDX chunk whose payload is not understood by this version of wc3libs.
+ * Keeping the complete chunk allows newer format extensions to survive a
+ * parse/write cycle without being silently discarded.
+ */
+public final class RawChunk extends Chunk {
+    private final Id _token;
+    private byte[] _data;
+
+    @Override
+    public Id getToken() {
+        return _token;
+    }
+
+    @Nonnull
+    public byte[] getData() {
+        return Arrays.copyOf(_data, _data.length);
+    }
+
+    public void setData(@Nonnull byte[] data) {
+        _data = Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public void write(@Nonnull Wc3BinOutputStream stream, @Nonnull MDX.EncodingFormat format) throws BinStream.StreamException {
+        stream.writeId(_token);
+        stream.writeUInt32(_data.length);
+        stream.writeBytes(_data);
+    }
+
+    @Override
+    public void write(@Nonnull Wc3BinOutputStream stream) throws BinStream.StreamException {
+        write(stream, MDX.EncodingFormat.AUTO);
+    }
+
+    public RawChunk(@Nonnull Id token, @Nonnull Wc3BinInputStream stream) throws BinInputStream.StreamException {
+        _token = token;
+
+        long size = stream.readUInt32("header_size");
+        if (size > Integer.MAX_VALUE) {
+            throw new BinStream.StreamException(stream, "unknown chunk is too large: " + size);
+        }
+
+        _data = stream.readBytes((int) size, "unknownChunkData");
+    }
+
+    public RawChunk(@Nonnull Id token, @Nonnull byte[] data) {
+        _token = token;
+        _data = Arrays.copyOf(data, data.length);
+    }
+}

--- a/src/test/java/wc3libs/misc/model/MDXTest.java
+++ b/src/test/java/wc3libs/misc/model/MDXTest.java
@@ -4,10 +4,16 @@ import net.moonlightflower.wc3libs.misc.model.MDX;
 import net.moonlightflower.wc3libs.misc.model.mdx.Bone;
 import net.moonlightflower.wc3libs.misc.model.mdx.BoneChunk;
 import net.moonlightflower.wc3libs.misc.model.mdx.Node;
+import net.moonlightflower.wc3libs.misc.model.mdx.RawChunk;
+import net.moonlightflower.wc3libs.bin.Wc3BinInputStream;
+import net.moonlightflower.wc3libs.bin.Wc3BinOutputStream;
+import net.moonlightflower.wc3libs.misc.Id;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import wc3libs.misc.Wc3LibTest;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class MDXTest extends Wc3LibTest {
@@ -50,5 +56,25 @@ public class MDXTest extends Wc3LibTest {
 
         Assert.assertTrue(patchedTrack, "Expected at least one translation track in PackHorse fixture");
         mdx.squish();
+    }
+
+    @Test()
+    public void preservesUnknownChunksWhenSquishing() throws IOException {
+        byte[] payload = new byte[] {0x01, 0x23, (byte) 0xFE, 0x45};
+        Wc3BinOutputStream input = new Wc3BinOutputStream(new ByteArrayOutputStream());
+        input.writeId(MDX.TOKEN);
+        input.writeId(Id.valueOf("FAFX"));
+        input.writeUInt32(payload.length);
+        input.writeBytes(payload);
+
+        byte[] original = input.getBytes();
+        MDX mdx = new MDX(new Wc3BinInputStream(new ByteArrayInputStream(original)));
+        Assert.assertEquals(mdx.getChunks().stream().filter(chunk -> chunk instanceof RawChunk).count(), 1L);
+
+        mdx.squish();
+
+        Wc3BinOutputStream output = new Wc3BinOutputStream(new ByteArrayOutputStream());
+        mdx.write(output);
+        Assert.assertEquals(output.getBytes(), original);
     }
 }


### PR DESCRIPTION
## Summary

- Preserve unknown top-level MDX chunks byte-for-byte during parse/write, including newer extension chunks such as `FAFX`, `BPOS`, and `CORN`.
- Make `MDX.squish()` round the sequence and geoset extents covered by the sibling implementation.
- Close file-backed MDX streams reliably and add a regression test for extension-chunk preservation through squishing.

## Validation

- `./gradlew.bat test` — passed.
- Sibling `war3-model` `npm test` — passed during the implementation audit.

## Known limitation

The Java wc3libs model classes remain classic-format parsers. Reforged fields nested inside known chunks, such as `GEOS` tangent/skin data and HD material/layer fields, are not interpreted by this Java implementation. w3p continues to use its vendored `war3-model` 4.0.1 converter/squisher for MDL→MDX and Reforged model processing.
